### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/app/src/main/java/com/sovworks/eds/fs/util/Util.java
+++ b/app/src/main/java/com/sovworks/eds/fs/util/Util.java
@@ -759,7 +759,7 @@ public class Util
 	 */
 	public static void skip(InputStream input, long num) throws IOException
 	{
-		int res = 0;
+		long res = 0;
 		while (res < num)
 		{
 			final long tmp = input.skip(num - res);


### PR DESCRIPTION
Fixes [https://github.com/pualluca/edslite/security/code-scanning/1](https://github.com/pualluca/edslite/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `res` from `int` to `long` to match the type of `tmp`. This will prevent any implicit narrowing conversion and ensure that the values are handled correctly without data loss or overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
